### PR TITLE
fix: 更新附件上传接口以适配最新 Memos API

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -15,16 +15,17 @@ const getVersion = () => {
   return "/v1";
 };
 
-exports.uploadFile = async (filePath) => {
+exports.uploadAttachment = async (filePath, memoName) => {
   const readFile = fs.readFileSync(filePath);
 
   return axios({
     method: "post",
-    url: getRequestUrl(`/api${getVersion()}/resources`),
+    url: getRequestUrl(`/api${getVersion()}/attachments`),
     data: {
       content: readFile.toString("base64"),
       filename: path.basename(filePath),
       type: mime.getType(filePath) || undefined,
+      memo: memoName,
     },
     headers: default_header,
   }).then((res) => res.data);


### PR DESCRIPTION
### 背景
- 最新 [Memos 文档](https://memos.apidocumentation.com/reference#tag/attachmentservice)将附件上传接口从 /resources 调整为 /attachments，导致原代码失效。
- 需要在创建 memo 后上传附件并关联 memo。

### 修改内容
- 将上传接口改为 /api{version}/attachments。
- 上传附件时增加 memo 字段关联对应 memo。
- 调整流程：先创建 memo，再上传附件并绑定。


